### PR TITLE
feat: adds ability to use guards on login route and interceptors on cb

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ This object dictates much of how the `OauthModule` operates under the hood. The 
 - name: `'google' | 'github'` - the name of the OAuth Provider. Currently only GitHub and Google are supported.
 - controller: [`ControllerOptions`](#controlleroptions) - options specific to the controller class
 - service: [`ServiceOptions`](#serviceoptions) - options specific to the service class
-- provide: `(user: any) => any` - a function to determine how to handle the returned user from the OAuth callout. This function can come from a class or can be a direct function.
+- provide: `(user: any) => any` - a function to determine how to handle the returned user from the OAuth callout. This function can come from a class or can be a direct function. Part of the `user` parameter is the token information retrieved from the token call (the OAuth callback) and the other part is the user information retrieved from the identity endpoint provided by the OAuth authority.
 
 ### ControllerOptions
 
 The object that dictates how the Controller class for the `OauthModule`.
 
-- root: string - used in conjunction with the `controllerRoot` property to set the path for the oauth login route. e.g. `/<globalPrefix>/<controllerRoot>/<root>` or `/api/auth/google`
-- callback: string - used to create the callback route for the current authority. Like the `root` option, takes into account the `controllerRoot` and any global prefix already in use. e.g. `/<globalPrefix>/<controllerRoot>/<callback>` or `/api/auth/google/callback` (in this case `callback` is `/google/callback`)
+- root: { path: string, guards: [CanActivate | Function] } - used in conjunction with the `controllerRoot` property to set the path for the oauth login route. e.g. `/<globalPrefix>/<controllerRoot>/<root>` or `/api/auth/google`. The `path` option is what sets the endpoint and the `guards` are passed into the `@UseGuards()` decorator, if there are any there.
+- callback: { path: string, interceptors: [NestInterceptor | Function] } - used to create the callback route for the current authority. Like the `root` option, takes into account the `controllerRoot` and any global prefix already in use. e.g. `/<globalPrefix>/<controllerRoot>/<callback>` or `/api/auth/google/callback` (in this case `callback` is `/google/callback`). Similar to the `root` property, `path` is used for the endpoint and `interceptors` are added to `@UseInterceptors()` if the array has any values in it.
 
 ### ServiceOptions
 
@@ -48,6 +48,11 @@ The object that dictates how the Controller class for the `OauthModule`.
 - clientSecret: string - the client secret for the authority you are using
 - callback: string - the callback url for the authority. This should match the `controller.callback` property, but should be a fully qualified URL instead of an endpoint path e.g. `http://localhost:3000/api/auth/google/callback`
 - prompt: string - the kind of prompt to use with the oauth flow, is a prompt is supported.
+- state: string - a state tracking token to know that the return of the OAuth call comes from the expected server.
+
+#### Specific Providers
+
+Each specific OAuth authority has their own provider values. These follow the values expected from the provider's OAuth documentation, usually changed from snake_case to camelCase. Intellisense should provide you with the options necessary. [Otherwise, you can look here](./lib/oauth.interface.ts)
 
 ## How it works
 

--- a/lib/oauth.constants.ts
+++ b/lib/oauth.constants.ts
@@ -5,14 +5,17 @@ export const user = 'getUser';
 export const github = {
   loginUrl: 'https://github.com/login/oauth/authorize',
   userUrl: 'https://api.github.com/user',
-  tokenUrl: 'https://github.com/login/oauth/access_token'
-}
+  tokenUrl: 'https://github.com/login/oauth/access_token',
+};
 export const google = {
   loginUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
   userUrl: 'https://www.googleapis.com/userinfo/v2/me',
-  tokenUrl: 'https://oauth2.googleapis.com/token'
-}
-export const JSONHeader = { 'Content-Type': 'application/json', Accept: 'application/json' };
+  tokenUrl: 'https://oauth2.googleapis.com/token',
+};
+export const JSONHeader = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+};
 export const oauth = {
   access: 'access_type',
   scope: 'scope',
@@ -22,5 +25,8 @@ export const oauth = {
   prompt: 'prompt',
   auth: 'authorization_code',
   redirect: 'redirect_uri',
-}
+  includeScopes: 'include_granted_scoped',
+  loginHint: 'login_hint',
+  state: 'state',
+};
 export const code = 'code';

--- a/lib/oauth.interface.ts
+++ b/lib/oauth.interface.ts
@@ -1,5 +1,9 @@
 import { CanActivate, NestInterceptor } from '@nestjs/common';
 
+/**
+ * G E N E R A L   I N T E R F A C E S
+ */
+
 export interface ControllerOptions {
   root: {
     path: string;
@@ -20,6 +24,15 @@ export interface ServiceOptions {
   state?: string;
 }
 
+interface OauthModuleOptionsBase {
+  controller: ControllerOptions;
+  provide: (user: any) => any;
+}
+
+/**
+ * G O O G L E   I N T E R F A C E S
+ */
+
 export interface GoogleServiceOptions extends ServiceOptions {
   scope: string[];
   callbackUrl: string;
@@ -29,25 +42,46 @@ export interface GoogleServiceOptions extends ServiceOptions {
   loginHint?: string;
 }
 
-export interface GithubServiceOptions extends ServiceOptions {
-  login?: string;
-  allowSignup?: boolean;
-}
-
-interface OauthModuleOptionsBase {
-  controller: ControllerOptions;
-  provide: (user: any) => any;
+export interface GoogleUser {
+  access_token: string;
+  expires_in: number;
+  refresh_token: string;
+  scope: string[];
+  token_type: string;
+  [index: string]: any;
 }
 
 interface GoogleOauthModuleOptions extends OauthModuleOptionsBase {
   name: 'google';
   service: GoogleServiceOptions;
+  provide: (user: GoogleUser) => any;
+}
+
+/**
+ * G I T H U B   I N T E R F A C E S
+ */
+
+export interface GithubServiceOptions extends ServiceOptions {
+  login?: string;
+  allowSignup?: boolean;
+}
+
+export interface GithubUser {
+  access_token: string;
+  scope: string;
+  token_type: string;
+  [index: string]: any;
 }
 
 interface GithubOauthModuleOptions extends OauthModuleOptionsBase {
   name: 'github';
   service: GithubServiceOptions;
+  provide: (user: GithubUser) => any;
 }
+
+/**
+ * M O D U L E   O P T I O N S
+ */
 
 export type OauthModuleProviderOptions =
   | GoogleOauthModuleOptions

--- a/lib/oauth.interface.ts
+++ b/lib/oauth.interface.ts
@@ -1,24 +1,57 @@
+import { CanActivate, NestInterceptor } from '@nestjs/common';
+
 export interface ControllerOptions {
-  root: string;
-  callback: string;
+  root: {
+    path: string;
+    guards?: (CanActivate | Function)[];
+  };
+  callback: {
+    path: string;
+    interceptors?: (NestInterceptor<any, any> | Function)[];
+  };
 }
 
 export interface ServiceOptions {
-  scope: string[];
+  scope?: string[];
   clientId: string;
   prompt?: string;
   clientSecret: string;
-  callback: string;
-  accessType?: string;
-  responseType?: string;
+  callbackUrl?: string;
+  state?: string;
 }
 
-export interface OauthModuleProviderOptions {
-  name: OauthProvider;
+export interface GoogleServiceOptions extends ServiceOptions {
+  scope: string[];
+  callbackUrl: string;
+  accessType?: string;
+  responseType?: string;
+  includeGrantedScopes?: boolean;
+  loginHint?: string;
+}
+
+export interface GithubServiceOptions extends ServiceOptions {
+  login?: string;
+  allowSignup?: boolean;
+}
+
+interface OauthModuleOptionsBase {
   controller: ControllerOptions;
-  service: ServiceOptions;
   provide: (user: any) => any;
 }
+
+interface GoogleOauthModuleOptions extends OauthModuleOptionsBase {
+  name: 'google';
+  service: GoogleServiceOptions;
+}
+
+interface GithubOauthModuleOptions extends OauthModuleOptionsBase {
+  name: 'github';
+  service: GithubServiceOptions;
+}
+
+export type OauthModuleProviderOptions =
+  | GoogleOauthModuleOptions
+  | GithubOauthModuleOptions;
 
 export interface OauthModuleOptions {
   authorities: OauthModuleProviderOptions[];

--- a/lib/utils/getLength.ts
+++ b/lib/utils/getLength.ts
@@ -1,0 +1,3 @@
+export function getLength(obj: any[]): number {
+  return (obj && obj.length) || 0;
+}

--- a/lib/utils/github-url.factory.ts
+++ b/lib/utils/github-url.factory.ts
@@ -2,9 +2,23 @@ import { github, oauth } from '../oauth.constants';
 import { GithubServiceOptions } from '../oauth.interface';
 
 export const createGithubLoginUrl = (options: GithubServiceOptions): string => {
-  return `${github.loginUrl}?${oauth.scope}=${options.scope.join(' ')}&${
-    oauth.id
-  }=${options.clientId}&${oauth.redirect}=${options.callbackUrl}`;
+  let queryString = `${oauth.id}=${options.clientId}`;
+  if (options?.scope.length) {
+    queryString += `&${oauth.scope}=${options.scope.join(' ')}`;
+  }
+  if (options.login) {
+    queryString += `&login=${options.login}`;
+  }
+  if (options.callbackUrl) {
+    queryString += `&${oauth.redirect}=${options.callbackUrl}`;
+  }
+  if (options.state) {
+    queryString += `&${oauth.state}=${options.state}`;
+  }
+  if (options.allowSignup !== null && options.allowSignup !== undefined) {
+    queryString += `&allow_signup=${options.allowSignup}`;
+  }
+  return `${github.loginUrl}?${queryString}`;
 };
 
 export const createGithubUserFunction = (
@@ -18,6 +32,7 @@ export const createGithubUserFunction = (
       client_secret: options.clientSecret,
       code,
       redirect_uri: options.callbackUrl,
+      state: options.state,
     },
     userUrl: github.userUrl,
   };

--- a/lib/utils/github-url.factory.ts
+++ b/lib/utils/github-url.factory.ts
@@ -1,20 +1,24 @@
-import { ServiceOptions } from '../oauth.interface';
-import { github, oauth } from 'lib/oauth.constants';
+import { github, oauth } from '../oauth.constants';
+import { GithubServiceOptions } from '../oauth.interface';
 
-export const createGithubLoginUrl = (options: ServiceOptions): string => {
-  console.log(options);
-  return `${github.loginUrl}?${oauth.scope}=${options.scope.join(' ')}&${oauth.id}=${options.clientId}&${oauth.redirect}=${options.callback}`;
+export const createGithubLoginUrl = (options: GithubServiceOptions): string => {
+  return `${github.loginUrl}?${oauth.scope}=${options.scope.join(' ')}&${
+    oauth.id
+  }=${options.clientId}&${oauth.redirect}=${options.callbackUrl}`;
 };
 
-export const createGithubUserFunction = (options: ServiceOptions, code: string): any => {
+export const createGithubUserFunction = (
+  options: GithubServiceOptions,
+  code: string,
+): any => {
   return {
     url: github.tokenUrl,
     options: {
       client_id: options.clientId,
       client_secret: options.clientSecret,
       code,
-      redirect_uri: options.callback,
+      redirect_uri: options.callbackUrl,
     },
     userUrl: github.userUrl,
-  }
-}
+  };
+};

--- a/lib/utils/google-url.factory.ts
+++ b/lib/utils/google-url.factory.ts
@@ -14,7 +14,10 @@ export const createGoogleLoginUrl = (options: GoogleServiceOptions): string => {
   if (options.responseType) {
     queryString += `&${oauth.response}=${options.responseType}`;
   }
-  if (options.includeGrantedScopes) {
+  if (
+    options.includeGrantedScopes !== null &&
+    options.includeGrantedScopes !== undefined
+  ) {
     queryString += `&${oauth.includeScopes}=${options.includeGrantedScopes}`;
   }
   if (options.loginHint) {

--- a/lib/utils/google-url.factory.ts
+++ b/lib/utils/google-url.factory.ts
@@ -1,18 +1,19 @@
 import { google, oauth } from '../oauth.constants';
-import { ServiceOptions } from '../oauth.interface';
+import { GoogleServiceOptions } from '../oauth.interface';
 
-export const createGoogleLoginUrl = (options: ServiceOptions): string => {
+export const createGoogleLoginUrl = (options: GoogleServiceOptions): string => {
   return `${google.loginUrl}?${oauth.scope}=${options.scope.join(' ')}&${
     oauth.access
   }=${options.accessType || 'online'}&${
     oauth.response
-  }=${options.responseType || 'code'}&${oauth.redirect}=${options.callback}&${
-    oauth.id
-  }=${options.clientId}&${oauth.prompt}=${options.prompt || 'select_account'}`;
+  }=${options.responseType || 'code'}&${oauth.redirect}=${
+    options.callbackUrl
+  }&${oauth.id}=${options.clientId}&${oauth.prompt}=${options.prompt ||
+    'select_account'}`;
 };
 
 export const createGoogleUserFunction = (
-  options: ServiceOptions,
+  options: GoogleServiceOptions,
   code: string,
 ): {
   url: string;
@@ -26,7 +27,7 @@ export const createGoogleUserFunction = (
       client_secret: options.clientSecret,
       code,
       grant_type: oauth.auth,
-      redirect_uri: options.callback,
+      redirect_uri: options.callbackUrl,
     },
     userUrl: google.userUrl,
   };

--- a/lib/utils/google-url.factory.ts
+++ b/lib/utils/google-url.factory.ts
@@ -2,14 +2,28 @@ import { google, oauth } from '../oauth.constants';
 import { GoogleServiceOptions } from '../oauth.interface';
 
 export const createGoogleLoginUrl = (options: GoogleServiceOptions): string => {
-  return `${google.loginUrl}?${oauth.scope}=${options.scope.join(' ')}&${
-    oauth.access
-  }=${options.accessType || 'online'}&${
-    oauth.response
-  }=${options.responseType || 'code'}&${oauth.redirect}=${
-    options.callbackUrl
-  }&${oauth.id}=${options.clientId}&${oauth.prompt}=${options.prompt ||
-    'select_account'}`;
+  let queryString = `${oauth.scope}=${options.scope.join(' ')}`;
+  queryString += `&${oauth.id}=${options.clientId}`;
+  queryString += `&${oauth.redirect}=${options.callbackUrl}`;
+  if (options.accessType) {
+    queryString += `&${oauth.access}=${options.accessType}`;
+  }
+  if (options.prompt) {
+    queryString += `&${oauth.prompt}=${options.prompt}`;
+  }
+  if (options.responseType) {
+    queryString += `&${oauth.response}=${options.responseType}`;
+  }
+  if (options.includeGrantedScopes) {
+    queryString += `&${oauth.includeScopes}=${options.includeGrantedScopes}`;
+  }
+  if (options.loginHint) {
+    queryString += `&${oauth.loginHint}=${options.loginHint}`;
+  }
+  if (options.state) {
+    queryString += `&${oauth.state}=${options.state}`;
+  }
+  return `${google.loginUrl}?${queryString}`;
 };
 
 export const createGoogleUserFunction = (

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './getLength';
+export * from './sanitize';
+export * from './service-function.factory';

--- a/lib/utils/service-function.factory.ts
+++ b/lib/utils/service-function.factory.ts
@@ -59,12 +59,16 @@ export const serviceGetUserFunction = (
         );
         break;
     }
+    let tokenData: Record<string, any>;
     return http
       .post(urlAndOptions.url, urlAndOptions.options, {
         headers: { ...JSONHeader },
       })
       .pipe(
-        map((res) => res.data),
+        map((res) => {
+          tokenData = res.data;
+          return tokenData;
+        }),
         switchMap((accessData) =>
           http.get(urlAndOptions.userUrl, {
             headers: {
@@ -73,7 +77,7 @@ export const serviceGetUserFunction = (
           }),
         ),
         map((userData) => userData.data),
-        switchMap((user) => of(service(user))),
+        switchMap((user) => of(service({ ...tokenData, ...user }))),
       );
   };
   return func;

--- a/test/main.ts
+++ b/test/main.ts
@@ -20,13 +20,17 @@ const bootstrap = async () => {
         {
           name: 'google',
           controller: {
-            root: 'google',
-            callback: '/google/callback',
+            root: {
+              path: 'google',
+            },
+            callback: {
+              path: '/google/callback',
+            },
           },
           service: {
             scope: ['profile', 'email'],
             clientId: process.env.GOOGLE_CLIENT,
-            callback: process.env.GOOGLE_CALLBACK,
+            callbackUrl: process.env.GOOGLE_CALLBACK,
             clientSecret: process.env.GOOGLE_SECRET,
             prompt: 'select_account',
           },
@@ -35,13 +39,17 @@ const bootstrap = async () => {
         {
           name: 'github',
           controller: {
-            callback: '/github/callback',
-            root: 'github',
+            callback: {
+              path: '/github/callback',
+            },
+            root: {
+              path: 'github',
+            },
           },
           service: {
             scope: ['user', 'repo'],
             clientId: process.env.GITHUB_CLIENT,
-            callback: process.env.GITHUB_CALLBACK,
+            callbackUrl: process.env.GITHUB_CALLBACK,
             clientSecret: process.env.GITHUB_SECRET,
             prompt: 'select_account',
           },


### PR DESCRIPTION
Due to a new options strucutre, it is possible to now use interceptors on the OAuth callback URL,
    which is useful when it comes to things like needing to add a cookie to the response, without having
    to use the `res` object in the controller or the service. Guards are also now available for the
    login URL to allow devs to keep users from hitting the URL if they are already logged in. The
    options objects for the Google and GitHub OAuth flows have also been updated to match the options
    allowed by the OAuth authoirites.
    
    BREAKING CHANGE: The `OauthModuleOptions` have been updated in the `controller` and `service`
    objects. In the `controller` object, each route is now a `path` and `guards` or `interceptors`
    property, and the `service` now is specific to each provider.