### PR TITLE
Feat/use decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,35 +32,69 @@ This object dictates much of how the `OauthModule` operates under the hood. The 
 - name: `'google' | 'github'` - the name of the OAuth Provider. Currently only GitHub and Google are supported.
 - controller: [`ControllerOptions`](#controlleroptions) - options specific to the controller class
 - service: [`ServiceOptions`](#serviceoptions) - options specific to the service class
-- provide: `(resp: {user: Record<any, any>, req: any }) => any` - a function to determine how to handle the returned user from the OAuth callout. This function can come from a class or can be a direct function. Part of the `user` parameter is the token information retrieved from the token call (the OAuth callback) and the other part is the user information retrieved from the identity endpoint provided by the OAuth authority. The Request object is also accessible for the case of wanting to set headers or cookies through packages similar to [`@nestjsplus/cookies`](https://github.com/nestjsplus/cookies).
+- provide: `(resp: {user: Record<string, any>, req: Record<string, any> }) => any` - a function to determine how to handle the returned user from the OAuth callout. This function can come from a class or can be a direct function. Part of the `user` parameter is the token information retrieved from the token call (the OAuth callback) and the other part is the user information retrieved from the identity endpoint provided by the OAuth authority. The Request object is also accessible for the case of wanting to set headers or cookies through packages similar to [`@nestjsplus/cookies`](https://github.com/nestjsplus/cookies).
 
 ### ControllerOptions
 
 The object that dictates how the Controller class for the `OauthModule`. Both `root` and `callback` have the same interface, and require the same values as shown below:
 
 - path: string - the location for the route to be bound
-- guards: Array<CanActivate> - guards to run on the route
-- pipes: Array<PipeTransform> - pipes to run on the route
-- interceptors: Array<NestInterceptor> - interceptors to run on the route
-- filters: Array<ExceptionFilter> - filters to run on the route
-- decorators: Array<MethodDecorators> - decorators to apply to the route. This is specifically added for things like `@OgmaSkip()` or `@Throttle()` though can be used with `@UsePipes()` and the rest of the Nest enhancer decorators if preferred.
+- guards: Array<CanActivate>, optional - guards to run on the route
+- pipes: Array<PipeTransform>, optional - pipes to run on the route
+- interceptors: Array<NestInterceptor>, optional - interceptors to run on the route
+- filters: Array<ExceptionFilter>, optional - filters to run on the route
+- decorators: Array<MethodDecorators>, optional - decorators to apply to the route. This is specifically added for things like `@OgmaSkip()` or `@Throttle()` though can be used with `@UsePipes()` and the rest of the Nest enhancer decorators if preferred.
 
 ### ServiceOptions
 
-- scope: string[] - an array of scopes to request from the authority provider. This **must** be passed as an array
+- scope: string[], optional - an array of scopes to request from the authority provider. This **must** be passed as an array
 - clientId: string - the client id for the authority you are using
 - clientSecret: string - the client secret for the authority you are using
-- callback: string - the callback url for the authority. This should match the `controller.callback` property, but should be a fully qualified URL instead of an endpoint path e.g. `http://localhost:3000/api/auth/google/callback`
-- prompt: string - the kind of prompt to use with the oauth flow, is a prompt is supported.
-- state: string - a state tracking token to know that the return of the OAuth call comes from the expected server.
+- callback: string, optional - the callback url for the authority. This should match the `controller.callback` property, but should be a fully qualified URL instead of an endpoint path e.g. `http://localhost:3000/api/auth/google/callback`
+- prompt: string, optional - the kind of prompt to use with the oauth flow, is a prompt is supported.
+- state: string, optional - a state tracking token to know that the return of the OAuth call comes from the expected server.
 
 > **NOTE**: if a state token is passed as a parameter, the `OauthService` method will check the returned state parameter against provided one, and will throw an `UnauthorizedException` if the values do not match.
+
+> **NOTE**: the Oauth module will not enforce most options on you, as not all OAuth authorities require all of these options. However, if your authority requires them, make sure you add the fields
 
 > **WARNING**: If no data modification happens on the return of `provide`, there will be a breaking error of the inability to convert a circularly structured JSON. This is intended.
 
 #### Specific Providers
 
 Each specific OAuth authority has their own provider values. These follow the values expected from the provider's OAuth documentation, usually changed from snake_case to camelCase. Intellisense should provide you with the options necessary. [Otherwise, you can look here](./lib/oauth.interface.ts)
+
+### Custom Service Options
+
+This module contains the ability to manage custom authorities that are not yet baked in as solutions. The same process is used overall, however, the service options object has a different structure to it:
+
+- loginUrl: string - the URL where the oauth flow is kicked off. This just needs to be the base URL, as this package will worry about building the rest of it for you (e.g. `https://accounts.google.com/o/oauth2/v2/auth`)
+- tokenUrl: string - the URL where the request is made to retrieve an access token
+- userUrl: string - the URL to determine the identity of the user who just logged in through the OAuth flow (e.g. `'https://www.googleapis.com/userinfo/v2/me`)
+- tokenHttpMethod: 'get' | 'post', optional - as some OAuth authorities allow the usage of `GET` methods when it comes to getting the token, this option is available to set that. By default, the value is `'post'`\*
+- loginUrlParams: [`LoginUrlParams`](#loginurlparams) - options that are to be used for the login URL. **Some of these options are reused when it comes to the token request as well. They only need to be defined here**.
+- tokenUrlParams: [`TokenUrlParams`](#tokenurlparams) - options to be passed to the Token URL defined above.
+
+> **Warning**: With authorities that use GET methods for the token flow, be very careful, as your client Id and client Secret will be exposed in the URL. Anyone who is sniffing HTTP traffic will be able to get a hold of these, and could end up using them elsewhere.
+
+#### LoginUrlParams
+
+- client_id: string
+- response_type: string - the response type for the OAuth request. Most of the time, this should be `'code'`
+- redirect_uri: string, optional
+- scope: string, optional - instead of being an array like in the other services, this time the scope is a string with space delimited values. This gets used directly in the call with no modifications, so make sure it matches what the OAuth provider expects
+- state: string, optional
+
+> Extra values can be added to the loginUrlParams object, so long as the OAuth authority will accept them, they should be added here.
+
+#### TokenUrlParams
+
+- grant_type: string
+- client_secret
+
+> The TokenUrlParams object takes the `redirect_uri` and the `client_id` from the `LoginUrlParams` object so that they do not have to be duplicated.
+
+> Extra values can be added to the tokenUrlParams object, so long as the OAuth authority will accept them, they should be added here.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The object that dictates how the Controller class for the `OauthModule`. Both `r
 
 > **NOTE**: if a state token is passed as a parameter, the `OauthService` method will check the returned state parameter against provided one, and will throw an `UnauthorizedException` if the values do not match.
 
+> **WARNING**: If no data modification happens on the return of `provide`, there will be a breaking error of the inability to convert a circularly structured JSON. This is intended.
+
 #### Specific Providers
 
 Each specific OAuth authority has their own provider values. These follow the values expected from the provider's OAuth documentation, usually changed from snake_case to camelCase. Intellisense should provide you with the options necessary. [Otherwise, you can look here](./lib/oauth.interface.ts)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,2 @@
+export { OauthModuleOptions } from './oauth.interface';
 export * from './oauth.module';

--- a/lib/oauth-core.module.ts
+++ b/lib/oauth-core.module.ts
@@ -9,7 +9,6 @@ import {
 } from '@nestjs/common';
 import { createConfigurableDynamicRootModule } from '@golevelup/nestjs-modules';
 import {
-  code,
   loginUrl,
   OAUTH_MODULE_OPTIONS,
   service,

--- a/lib/oauth-core.module.ts
+++ b/lib/oauth-core.module.ts
@@ -5,6 +5,7 @@ import {
   HttpService,
   Module,
   Query,
+  Req,
 } from '@nestjs/common';
 import { createConfigurableDynamicRootModule } from '@golevelup/nestjs-modules';
 import {
@@ -18,6 +19,7 @@ import { OauthController } from './oauth.controller';
 import {
   OauthModuleOptions,
   OauthModuleProviderOptions,
+  OauthCodeInterface,
 } from './oauth.interface';
 import { OauthService } from './oauth.service';
 import {
@@ -60,9 +62,10 @@ export class OauthCoreModule extends createConfigurableDynamicRootModule<
             return this[service][serviceLoginFuncName]();
           };
           OauthController.prototype[controllerCallbackFunction] = function(
-            code: string,
+            query: OauthCodeInterface,
+            req: any,
           ) {
-            return this[service][serviceCallbackFuncName](code);
+            return this[service][serviceCallbackFuncName](query, req);
           };
           // SERVICE OVERRIDING
           OauthService.prototype[serviceLoginFuncName] = function() {
@@ -98,7 +101,8 @@ export class OauthCoreModule extends createConfigurableDynamicRootModule<
             OauthController,
             controllerCallbackFunction,
           );
-          Query(code)(OauthController.prototype, controllerCallbackFunction, 0);
+          Query()(OauthController.prototype, controllerCallbackFunction, 0);
+          Req()(OauthController.prototype, controllerCallbackFunction, 1);
         });
       },
       inject: [OAUTH_MODULE_OPTIONS, HttpService],

--- a/lib/oauth.interface.ts
+++ b/lib/oauth.interface.ts
@@ -34,7 +34,10 @@ export interface ServiceOptions {
 
 interface OauthModuleOptionsBase {
   controller: ControllerOptions;
-  provide: (resp: { user: any; req: any }) => any;
+  provide: (resp: {
+    user: Record<string, any>;
+    req: Record<string, any>;
+  }) => any;
 }
 
 /**
@@ -88,12 +91,31 @@ interface GithubOauthModuleOptions extends OauthModuleOptionsBase {
 }
 
 /**
+ * C U S T O M   I N T E R F A C E
+ */
+
+export interface CustomServiceOptions {
+  loginUrl: string;
+  tokenUrl: string;
+  userUrl: string;
+  loginUrlParams: Record<string, any>;
+  tokenUrlParams: Record<string, any>;
+  tokenHttpMethod: 'get' | 'post';
+}
+
+interface CustomOauthModuleOptions extends OauthModuleOptionsBase {
+  name: string;
+  service: CustomServiceOptions;
+}
+
+/**
  * M O D U L E   O P T I O N S
  */
 
 export type OauthModuleProviderOptions =
   | GoogleOauthModuleOptions
-  | GithubOauthModuleOptions;
+  | GithubOauthModuleOptions
+  | CustomOauthModuleOptions;
 
 export interface OauthModuleOptions {
   authorities: OauthModuleProviderOptions[];

--- a/lib/oauth.interface.ts
+++ b/lib/oauth.interface.ts
@@ -98,8 +98,19 @@ export interface CustomServiceOptions {
   loginUrl: string;
   tokenUrl: string;
   userUrl: string;
-  loginUrlParams: Record<string, any>;
-  tokenUrlParams: Record<string, any>;
+  loginUrlParams: {
+    client_id: string;
+    response_type: string;
+    redirect_uri?: string;
+    scope?: string;
+    state?: string;
+    [index: string]: any;
+  };
+  tokenUrlParams: {
+    grant_type: string;
+    client_secret: string;
+    [index: string]: any;
+  };
   tokenHttpMethod: 'get' | 'post';
 }
 

--- a/lib/oauth.interface.ts
+++ b/lib/oauth.interface.ts
@@ -111,7 +111,7 @@ export interface CustomServiceOptions {
     client_secret: string;
     [index: string]: any;
   };
-  tokenHttpMethod: 'get' | 'post';
+  tokenHttpMethod?: 'get' | 'post';
 }
 
 interface CustomOauthModuleOptions extends OauthModuleOptionsBase {

--- a/lib/oauth.interface.ts
+++ b/lib/oauth.interface.ts
@@ -1,18 +1,26 @@
-import { CanActivate, NestInterceptor } from '@nestjs/common';
+import {
+  CanActivate,
+  ExceptionFilter,
+  NestInterceptor,
+  PipeTransform,
+} from '@nestjs/common';
 
 /**
  * G E N E R A L   I N T E R F A C E S
  */
 
+export interface RouteOptions {
+  path: string;
+  pipes?: (PipeTransform | Function)[];
+  guards?: (CanActivate | Function)[];
+  interceptors?: (NestInterceptor | Function)[];
+  filters?: (ExceptionFilter | Function)[];
+  decorators?: MethodDecorator[];
+}
+
 export interface ControllerOptions {
-  root: {
-    path: string;
-    guards?: (CanActivate | Function)[];
-  };
-  callback: {
-    path: string;
-    interceptors?: (NestInterceptor<any, any> | Function)[];
-  };
+  root: RouteOptions;
+  callback: RouteOptions;
 }
 
 export interface ServiceOptions {

--- a/lib/oauth.interface.ts
+++ b/lib/oauth.interface.ts
@@ -34,7 +34,7 @@ export interface ServiceOptions {
 
 interface OauthModuleOptionsBase {
   controller: ControllerOptions;
-  provide: (user: any) => any;
+  provide: (resp: { user: any; req: any }) => any;
 }
 
 /**
@@ -62,7 +62,7 @@ export interface GoogleUser {
 interface GoogleOauthModuleOptions extends OauthModuleOptionsBase {
   name: 'google';
   service: GoogleServiceOptions;
-  provide: (user: GoogleUser) => any;
+  provide: (resp: { user: GoogleUser; req: any }) => any;
 }
 
 /**
@@ -84,7 +84,7 @@ export interface GithubUser {
 interface GithubOauthModuleOptions extends OauthModuleOptionsBase {
   name: 'github';
   service: GithubServiceOptions;
-  provide: (user: GithubUser) => any;
+  provide: (resp: { user: GithubUser; req: any }) => any;
 }
 
 /**
@@ -101,3 +101,14 @@ export interface OauthModuleOptions {
 }
 
 export type OauthProvider = 'google' | 'github';
+
+export interface OauthCodeInterface {
+  code: string;
+  state?: string;
+}
+
+export interface GoogleOauthCode extends OauthCodeInterface {
+  scope: string;
+  authUser: string;
+  prompt: string;
+}

--- a/lib/utils/apply-decorators.ts
+++ b/lib/utils/apply-decorators.ts
@@ -1,0 +1,54 @@
+import {
+  UseFilters,
+  UseGuards,
+  UseInterceptors,
+  UsePipes,
+} from '@nestjs/common';
+import { RouteOptions } from '../oauth.interface';
+import { getLength } from './getLength';
+
+export function applyMethodDecorator(
+  decorator: (...args: any) => MethodDecorator,
+  value: any,
+  target: Record<any, any>,
+  property: string,
+) {
+  decorator(value)(
+    target,
+    property,
+    Object.getOwnPropertyDescriptor(target.prototype, property),
+  );
+}
+
+export function checkOptions(
+  options: RouteOptions,
+  target: Record<any, any>,
+  property: string,
+) {
+  if (getLength(options.guards)) {
+    applyMethodDecorator(UseGuards, options.guards, target, property);
+  }
+  if (getLength(options.interceptors)) {
+    applyMethodDecorator(
+      UseInterceptors,
+      options.interceptors,
+      target,
+      property,
+    );
+  }
+  if (getLength(options.pipes)) {
+    applyMethodDecorator(UsePipes, options.pipes, target, property);
+  }
+  if (getLength(options.filters)) {
+    applyMethodDecorator(UseFilters, options.filters, target, property);
+  }
+  if (getLength(options.decorators)) {
+    options.decorators.forEach((decorator) => {
+      decorator(
+        target,
+        property,
+        Object.getOwnPropertyDescriptor(target.prototype, property),
+      );
+    });
+  }
+}

--- a/lib/utils/custom-url.factory.ts
+++ b/lib/utils/custom-url.factory.ts
@@ -1,0 +1,42 @@
+import { CustomServiceOptions } from '../oauth.interface';
+
+export const createCustomLoginUrl = (options: CustomServiceOptions): string => {
+  let queryString = '';
+  const loginParams = options.loginUrlParams;
+  Object.keys(loginParams).forEach((key) => {
+    queryString += `${key}=${loginParams[key]}&`;
+  });
+  return `${options.loginUrl}?${queryString.substring(
+    0,
+    queryString.length - 1,
+  )}`;
+};
+
+export const createCustomUserFunction = (
+  options: CustomServiceOptions,
+  code: string,
+): {
+  url: string;
+  userUrl: string;
+  options: {
+    client_id: string;
+    client_secret: string;
+    code: string;
+    redirect_uri: string;
+    state: string;
+  };
+} => {
+  const tokenOpts = {};
+  const tokenParams = options.tokenUrlParams;
+  Object.keys(tokenParams).forEach((key) => {
+    tokenOpts[key] = tokenParams[key];
+  });
+  return {
+    url: options.tokenUrl,
+    userUrl: options.userUrl,
+    options: {
+      code,
+      ...tokenOpts,
+    },
+  } as any;
+};

--- a/lib/utils/custom-url.factory.ts
+++ b/lib/utils/custom-url.factory.ts
@@ -1,15 +1,11 @@
 import { CustomServiceOptions } from '../oauth.interface';
 
 export const createCustomLoginUrl = (options: CustomServiceOptions): string => {
-  let queryString = '';
   const loginParams = options.loginUrlParams;
-  Object.keys(loginParams).forEach((key) => {
-    queryString += `${key}=${loginParams[key]}&`;
-  });
-  return `${options.loginUrl}?${queryString.substring(
-    0,
-    queryString.length - 1,
-  )}`;
+  const queryString = Object.keys(loginParams).map(
+    (key) => `${key}=${loginParams[key]}`,
+  );
+  return `${options.loginUrl}?${queryString.join('&')}`;
 };
 
 export const createCustomUserFunction = (
@@ -26,11 +22,18 @@ export const createCustomUserFunction = (
     state: string;
   };
 } => {
-  const tokenOpts = {};
-  const tokenParams = options.tokenUrlParams;
-  Object.keys(tokenParams).forEach((key) => {
-    tokenOpts[key] = tokenParams[key];
-  });
+  const { redirect_uri, client_id } = options.loginUrlParams;
+  const tokenOpts = { ...options.tokenUrlParams, redirect_uri, client_id };
+  if (options.tokenHttpMethod === 'get') {
+    const queryString =
+      Object.keys(tokenOpts)
+        .map((key) => `${key}=${tokenOpts[key]}`)
+        .join('&') + `&code=${code}`;
+    return {
+      url: options.tokenUrl + `?${queryString}`,
+      userUrl: options.userUrl,
+    } as any;
+  }
   return {
     url: options.tokenUrl,
     userUrl: options.userUrl,

--- a/lib/utils/github-url.factory.ts
+++ b/lib/utils/github-url.factory.ts
@@ -24,7 +24,17 @@ export const createGithubLoginUrl = (options: GithubServiceOptions): string => {
 export const createGithubUserFunction = (
   options: GithubServiceOptions,
   code: string,
-): any => {
+): {
+  url: string;
+  userUrl: string;
+  options: {
+    client_id: string;
+    client_secret: string;
+    code: string;
+    redirect_uri: string;
+    state: string;
+  };
+} => {
   return {
     url: github.tokenUrl,
     options: {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './apply-decorators';
 export * from './getLength';
 export * from './sanitize';
 export * from './service-function.factory';

--- a/lib/utils/service-function.factory.ts
+++ b/lib/utils/service-function.factory.ts
@@ -3,12 +3,16 @@ import { from } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { JSONHeader } from '../oauth.constants';
 import {
+  CustomServiceOptions,
   GithubServiceOptions,
   GoogleServiceOptions,
   OauthCodeInterface,
-  OauthProvider,
   ServiceOptions,
 } from '../oauth.interface';
+import {
+  createCustomLoginUrl,
+  createCustomUserFunction,
+} from './custom-url.factory';
 import {
   createGithubLoginUrl,
   createGithubUserFunction,
@@ -19,8 +23,8 @@ import {
 } from './google-url.factory';
 
 export const serviceLoginFunction = (
-  provider: OauthProvider,
-  options: ServiceOptions,
+  provider: string,
+  options: ServiceOptions | CustomServiceOptions,
 ): { url: string; provider: string } => {
   let url: string;
   switch (provider) {
@@ -30,13 +34,16 @@ export const serviceLoginFunction = (
     case 'github':
       url = createGithubLoginUrl(options as GithubServiceOptions);
       break;
+    default:
+      url = createCustomLoginUrl(options as CustomServiceOptions);
+      break;
   }
   return { url, provider };
 };
 
 export const serviceGetUserFunction = (
-  provider: OauthProvider,
-  options: ServiceOptions,
+  provider: string,
+  options: ServiceOptions | CustomServiceOptions,
   service: (resp: { user: Record<any, any>; req: any }) => any,
   http: HttpService,
 ): any => {
@@ -59,40 +66,53 @@ export const serviceGetUserFunction = (
           oauthResp.code,
         );
         break;
+      default:
+        urlAndOptions = createCustomUserFunction(
+          options as CustomServiceOptions,
+          oauthResp.code,
+        );
+        break;
     }
-    if (options.state) {
-      if (options.state !== oauthResp.state) {
+    const state =
+      (options as ServiceOptions).state ||
+      (options as CustomServiceOptions)?.loginUrlParams.state ||
+      undefined;
+    if (state) {
+      if (state !== oauthResp.state) {
         throw new ForbiddenException(
-          `Expected a state value of ${options.state} but instead got ${oauthResp.state}`,
+          `Expected a state value of ${state} but instead got ${oauthResp.state}`,
         );
       }
     }
     let tokenData: Record<string, any>;
-    return http
-      .post(urlAndOptions.url, urlAndOptions.options, {
-        headers: { ...JSONHeader },
-      })
-      .pipe(
-        map((res) => {
-          tokenData = res.data;
-          return tokenData;
+    const axiosReq = {
+      method:
+        (options as CustomServiceOptions).tokenHttpMethod || ('post' as const),
+      url: urlAndOptions.url,
+      data: urlAndOptions.options,
+      headers: JSONHeader,
+    };
+    return http.request(axiosReq).pipe(
+      map((res) => {
+        tokenData = res.data;
+        return tokenData;
+      }),
+      switchMap((accessData) =>
+        http.get(urlAndOptions.userUrl, {
+          headers: {
+            Authorization: `Bearer ${accessData.access_token}`,
+          },
         }),
-        switchMap((accessData) =>
-          http.get(urlAndOptions.userUrl, {
-            headers: {
-              Authorization: `Bearer ${accessData.access_token}`,
-            },
-          }),
-        ),
-        map((userData) => userData.data),
-        switchMap((user) => {
-          const retVal = service({ user: { ...tokenData, ...user }, req });
-          if (retVal.pipe) {
-            return retVal;
-          }
-          return from(retVal);
-        }),
-      );
+      ),
+      map((userData) => userData.data),
+      switchMap((user) => {
+        const retVal = service({ user: { ...tokenData, ...user }, req });
+        if (retVal.pipe) {
+          return retVal;
+        }
+        return from(retVal);
+      }),
+    );
   };
   return func;
 };

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -18,13 +18,17 @@ describe('AppController (e2e)', () => {
             {
               name: 'google',
               controller: {
-                root: 'google',
-                callback: '/google/callback',
+                root: {
+                  path: 'google',
+                },
+                callback: {
+                  path: '/google/callback',
+                },
               },
               service: {
                 scope: ['profile', 'email'],
                 clientId: process.env.GOOGLE_CLIENT,
-                callback: process.env.GOOGLE_CALLBACK,
+                callbackUrl: process.env.GOOGLE_CALLBACK,
                 clientSecret: process.env.GOOGLE_SECRET,
                 prompt: 'select_account',
               },

--- a/test/app.module.ts
+++ b/test/app.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { OgmaModule, OgmaSkip } from '@ogma/nestjs-module';
+import { ExpressParser } from '@ogma/platform-express';
 import { OauthModule } from '../lib';
 import { waitFor } from './utils';
 
@@ -20,6 +22,7 @@ async function saveUser(user: any) {
             },
             callback: {
               path: '/google/callback',
+              decorators: [OgmaSkip()],
             },
           },
           service: {
@@ -29,6 +32,7 @@ async function saveUser(user: any) {
             clientSecret: process.env.GOOGLE_SECRET,
             prompt: 'select_account',
             responseType: 'code',
+            state: 'some google state token',
           },
           provide: saveUser,
         },
@@ -48,10 +52,21 @@ async function saveUser(user: any) {
             callbackUrl: process.env.GITHUB_CALLBACK,
             clientSecret: process.env.GITHUB_SECRET,
             prompt: 'select_account',
+            state: 'some github state token',
           },
           provide: saveUser,
         },
       ],
+    }),
+    OgmaModule.forRoot({
+      service: {
+        color: true,
+        json: false,
+        application: 'Oauth',
+      },
+      interceptor: {
+        http: ExpressParser,
+      },
     }),
   ],
 })

--- a/test/app.module.ts
+++ b/test/app.module.ts
@@ -6,7 +6,8 @@ import { waitFor } from './utils';
 
 async function saveUser(user: any) {
   await waitFor(3000);
-  return user;
+  console.log(user.req);
+  return user.user;
 }
 
 @Module({

--- a/test/app.module.ts
+++ b/test/app.module.ts
@@ -55,6 +55,40 @@ async function saveUser(user: any) {
             prompt: 'select_account',
             state: 'some github state token',
           },
+          provide: (response) => {
+            console.log(response.req);
+            return response.user;
+          },
+        },
+        {
+          name: 'customGoogle',
+          controller: {
+            root: {
+              path: 'custom-google',
+            },
+            callback: {
+              path: 'custom-google/callback',
+            },
+          },
+          service: {
+            loginUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+            tokenUrl: 'https://oauth2.googleapis.com/token',
+            userUrl: 'https://www.googleapis.com/userinfo/v2/me',
+            loginUrlParams: {
+              client_id: process.env.GOOGLE_CLIENT,
+              redirect_uri: process.env.GOOGLE_CUSTOM_CALLBACK,
+              scope: 'email profile',
+              prompt: 'select_account',
+              response_type: 'code',
+            },
+            tokenHttpMethod: 'post',
+            tokenUrlParams: {
+              client_id: process.env.GOOGLE_CLIENT,
+              client_secret: process.env.GOOGLE_SECRET,
+              grant_type: 'authorization_code',
+              redirect_uri: process.env.GOOGLE_CUSTOM_CALLBACK,
+            },
+          },
           provide: saveUser,
         },
       ],

--- a/test/app.module.ts
+++ b/test/app.module.ts
@@ -68,6 +68,7 @@ async function saveUser(user: any) {
             },
             callback: {
               path: 'custom-google/callback',
+              decorators: [OgmaSkip()],
             },
           },
           service: {
@@ -83,10 +84,8 @@ async function saveUser(user: any) {
             },
             tokenHttpMethod: 'post',
             tokenUrlParams: {
-              client_id: process.env.GOOGLE_CLIENT,
               client_secret: process.env.GOOGLE_SECRET,
               grant_type: 'authorization_code',
-              redirect_uri: process.env.GOOGLE_CUSTOM_CALLBACK,
             },
           },
           provide: saveUser,


### PR DESCRIPTION
Allows for the usage of all decorators, the comparison of `state` tokens to help mitigate XSS attacks, and allows devs access to the `req` object to allow for dynamically setting headers with interceptors and `post-controller` logic.